### PR TITLE
Fixed iOS issue where clicking the background would not close the dialog.

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 			</div>
 		</article>
 
-		<div class="avgrund-cover"></div>
+		<div class="avgrund-cover" onclick="void(0);"></div>
 
 		<script type="text/javascript" src="js/avgrund.js"></script>
 


### PR DESCRIPTION
This was done by adding a dummy onclick event to the avgrund-cover div, making it 'clickable' to the mobile browser.
